### PR TITLE
ptable-type in ck_create_pert_params

### DIFF
--- a/R/ck_create_pert_params.R
+++ b/R/ck_create_pert_params.R
@@ -29,11 +29,16 @@ ck_create_pert_params <- function(bigN, smallN, pTable, sTable, mTable) {
   out <- new("pert_params")
 
   convert_from_ptable <- function(pTable) {
-    . <- i <- p <- v <- NULL
+    . <- i <- p_int_ub <- v <- NULL
     if (isS4(pTable) && class(pTable)=="ptable") {
-      pTable <- slot(pTable, "pTable")[,.(i,p,v)]
-      setnames(pTable, c("i", "kum_p_o", "diff"))
-      attr(pTable, "type") <- "destatis"
+      pType <- slot(pTable, "type")
+      if (pType == "destatis"){
+        pTable <- slot(pTable, "pTable")[, .(i, p_int_ub, v)]
+        setnames(pTable, c("i", "kum_p_o", "diff"))
+      }
+      if (pType == "abs"){
+        pTable <- slot(pTable, "pTable")
+      }
     }
     pTable
   }


### PR DESCRIPTION
@bernhard-da Some modifications (that I just wrote down without the possibility to test them; so you may have to adjust my proposal) in order to use the the pre-set format of a ptable-object (`type =  'abs' or 'destatis'`) that I just updated. Further, there are some minor bugfixes regarding the columns of the ptable (i.e. `p_int_ub`).