### PR TITLE
add github-url to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,3 +36,4 @@ Author: Bernhard Meindl [aut, cre]
 Maintainer: Bernhard Meindl <bernhard.meindl@statistik.gv.at>
 LazyData: true
 BugReports: https://github.com/sdcTools/cellKey/issues
+URL: https://github.com/sdcTools/cellKey


### PR DESCRIPTION
Adding this seems redundant because of the `BugReports` field. However, this will make sure the pkgdown site links back to the github page.